### PR TITLE
Update caddy proxy settings

### DIFF
--- a/docs/setup-caddy-proxy-with-minio.md
+++ b/docs/setup-caddy-proxy-with-minio.md
@@ -21,7 +21,9 @@ Create a caddy configuration file as below, change the ip addresses according to
 your.public.com 
 
 proxy / localhost:9000 {
-    transparent
+    proxy_header X-Forwarded-Proto {scheme}
+    proxy_header X-Forwarded-Host {host}
+    proxy_header Host {host}
 }
 
 ```


### PR DESCRIPTION
transparent sets X-Forwarded-Proto along with these three headers.  This header breaks minio giving 'x-amz-content-sha256' header mismatch issues.

This is working as of the following docker image:

minio/minio                      <none>              a3b11c5cd785        4 weeks ago         798.5 MB