### PR TITLE
Disallow unnecessary injection of client IP from untrusted header

### DIFF
--- a/docs/setup-apache-http-proxy-with-minio.md
+++ b/docs/setup-apache-http-proxy-with-minio.md
@@ -35,8 +35,6 @@ Create a file under the Apache configuration directory, e.g., ``/etc/httpd/conf.
 
     ProxyPass / http://localhost:9000/
     ProxyPassReverse / http://localhost:9000/
-
-    RemoteIPHeader X-Forwarded-For
 </VirtualHost>
 ```
 


### PR DESCRIPTION
Apache mod_proxy sets X-Forwarded-For per default, RemoteIPHeader would needlessly allow setting of the client ip per header sent from the original upstream client.
https://httpd.apache.org/docs/current/mod/mod_proxy.html#x-headers