### PR TITLE
Note about large files

### DIFF
--- a/docs/setup-nginx-proxy-with-minio.md
+++ b/docs/setup-nginx-proxy-with-minio.md
@@ -33,6 +33,7 @@ Note:
 
 * Replace example.com with your own hostname.
 * Replace ``http://localhost:9000``  with your own server name.
+* Add ``client_max_body_size 1000m;`` in the ``http`` context in order to be able to upload large files — simply adjust the value accordingly. The default value is `1m` which is far too low for most scenarios.
 
 ## 4. Recipe Steps
 


### PR DESCRIPTION
Add a note (with filled-in example) about adding the ability to upload files larger than the default value for client_max_body_size.