### PR TITLE
Update aws-sdk-for-php-with-minio.md

### DIFF
--- a/docs/aws-sdk-for-php-with-minio.md
+++ b/docs/aws-sdk-for-php-with-minio.md
@@ -29,6 +29,7 @@ $s3 = new Aws\S3\S3Client([
                 'key'    => 'YOUR-ACCESSKEYID',
                 'secret' => 'YOUR-SECRETACCESSKEY',
             ],
+        'use_path_style_endpoint' => true,
 ]);
 
 


### PR DESCRIPTION
Aws changed the default path style in version 3.2.85 of the php sdk. Without the added change that reverts back to the older style, the example code won't work with a default installation of minio as it will try to connect to `http://testbucket.localhost:9000` in the example.

More information here: https://github.com/aws/aws-sdk-php/blob/master/CHANGELOG.md#3285---2017-05-30