### PR TITLE
Fixed link and docker command for usage with certbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Note: You can also refer to [Awesome Minio](https://github.com/minio/awesome-min
 - [restic with Minio](./docs/restic-with-minio.md)
 - [S3cmd with Minio](./docs/s3cmd-with-minio.md)
 - [Aggregate Apache logs with fluentd and Minio](./docs/aggregate-apache-logs-with-fluentd-and-minio.md)
-- [Generate Let's Encypt certificate using Concert for Minio](./docs/generate-lets-encypt-certificate-using-concert-for-minio.md)
+- [Generate Let's Encrypt certificate using Certbot for Minio](./docs/generate-lets-encypt-certificate-using-certbot-for-minio.md)
 - [Setup Caddy proxy with Minio](./docs/setup-caddy-proxy-with-minio.md)
 - [Setup Nginx proxy with Minio](./docs/setup-nginx-proxy-with-minio.md)
 - [Setup Apache HTTP proxy with Minio](./docs/setup-apache-http-proxy-with-minio.md)

--- a/docs/generate-lets-encypt-certificate-using-certbot-for-minio.md
+++ b/docs/generate-lets-encypt-certificate-using-certbot-for-minio.md
@@ -57,7 +57,7 @@ $ sudo ./minio server --address ":443" /mnt/data
 
 If you are using dockerized version of Minio then you would need to
 ```sh
-$ sudo docker run -p 443:443 -v /home/user/.minio:/root/.minio/ -v /home/user/data:/data server --address ":443" /data
+$ sudo docker run -p 443:443 -v /home/user/.minio:/root/.minio/ -v /home/user/data:/data minio/minio server --address ":443" /data
 ```
 
 ### Step 7: Visit <https://myminio.com> in the browser.


### PR DESCRIPTION
Updated the title/link on the readme.md and fixed the docker command that was missing the minio package