### PR TITLE
added how to using minio with laravel

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ Note: You can also refer to [Awesome Minio](https://github.com/minio/awesome-min
 - [How to use CloudBerry Drive with Minio](./docs/how-to-use-cloudberry-drive-with-minio.md)
 - [How to use AWS SDK for Java for encryption with Minio Server](./docs/how-to-use-aws-sdk-java-encryption.md)
 - [How to use s3fs-fuse with Minio](./docs/s3fs-fuse-with-minio.md)
+- [How to use Minio Server as Laravel Custom File Storage](./docs/how-to-use-minio-as-laravel-file-storage.md)

--- a/docs/how-to-use-minio-as-laravel-file-storage.md
+++ b/docs/how-to-use-minio-as-laravel-file-storage.md
@@ -100,3 +100,6 @@ Or you can set default cloud driver to `minio` in `filesystems.php` config file 
 ```php
 'cloud' => env('FILESYSTEM_CLOUD', 'minio'),
 ```
+
+##  Sample Project
+If you want, you could explore [laravel-minio-sample](https://github.com/m2sh/laravel-minio-sample) project and the  [unit tests](https://github.com/m2sh/laravel-minio-sample/blob/master/tests/Unit/MinioStorageTest.php) for understanding how to use Minio Server with Laravel

--- a/docs/how-to-use-minio-as-laravel-file-storage.md
+++ b/docs/how-to-use-minio-as-laravel-file-storage.md
@@ -1,0 +1,102 @@
+# How to use Minio Server as [Laravel](https://laravel.com) Custom File Storage 
+
+`Laravel` has a customable file storage system with ability to create custom drivers for it. In this recipe we will implement a custom file system driver to use Minio server for managing files.
+
+## 1. Prerequisites
+
+Install Minio Server from [here](http://docs.minio.io/docs/minio).
+
+## 2. Install Required Dependency for Laravel
+
+Install `league/flysystem` package for [`aws-s3`](https://github.com/thephpleague/flysystem-aws-s3-v3) :
+
+```
+composer require league/flysystem-aws-s3-v3
+```
+
+
+## 3. Create Minio Storage ServiceProvider 
+Create `MinioStorageServiceProvider.php` file in `app/Providers/` directory with this content:
+
+```php
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+use Aws\S3\S3Client;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\Filesystem;
+use Storage;
+
+class MinioStorageServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+      Storage::extend('minio', function ($app, $config) {
+          $client = new S3Client([
+              'credentials' => [
+                  'key'    => $config["key"],
+                  'secret' => $config["secret"]
+              ],
+              'region'      => $config["region"],
+              'version'     => "latest",
+              'bucket_endpoint' => false,
+              'use_path_style_endpoint' => true,
+              'endpoint'    => $config["endpoint"],
+          ]);
+          return new Filesystem(new AwsS3Adapter($client, $config["bucket"]));
+      });
+    }
+
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+
+    }
+}
+```
+
+Register service provider by adding this line in `config/app.php` on `providers` section :  
+```php
+App\Providers\MinioStorageServiceProvider::class
+```
+
+Add config for minio in `disks` section of `config/filesystems.php` file :
+
+```php
+  'disks' => [
+    // other disks
+
+    'minio' => [
+        'driver' => 'minio',
+        'key' => env('MINIO_KEY', 'your minio server key'),
+        'secret' => env('MINIO_SECRET', 'your minio server secret'),
+        'region' => 'us-east-1',
+        'bucket' => env('MINIO_BUCKET','your minio bucket name'),
+        'endpoint' => env('MINIO_ENDPOINT','http://localhost:9000')
+    ]
+
+  ]
+```  
+Note : `region` is not required & can be sets to anything.
+
+## 4. Use Storage with Minio in Laravel
+Now you can use `disk` method on storage facade to use minio driver :  
+```php
+Storage::disk('minio')->put('avatars/1', $fileContents);
+```
+Or you can set default cloud driver to `minio` in `filesystems.php` config file :
+```php
+'cloud' => env('FILESYSTEM_CLOUD', 'minio'),
+```

--- a/docs/how-to-use-minio-as-laravel-file-storage.md
+++ b/docs/how-to-use-minio-as-laravel-file-storage.md
@@ -1,10 +1,10 @@
 # How to use Minio Server as [Laravel](https://laravel.com) Custom File Storage 
 
-`Laravel` has a customable file storage system with ability to create custom drivers for it. In this recipe we will implement a custom file system driver to use Minio server for managing files.
+`Laravel` has a customizable file storage system with ability to create custom drivers for it. In this recipe we will implement a custom file system driver to use Minio server for managing files.
 
 ## 1. Prerequisites
 
-Install Minio Server from [here](http://docs.minio.io/docs/minio).
+Install Minio Server from [here](https://www.minio.io/downloads.html).
 
 ## 2. Install Required Dependency for Laravel
 
@@ -89,7 +89,7 @@ Add config for minio in `disks` section of `config/filesystems.php` file :
 
   ]
 ```  
-Note : `region` is not required & can be sets to anything.
+Note : `region` is not required & can be set to anything.
 
 ## 4. Use Storage with Minio in Laravel
 Now you can use `disk` method on storage facade to use minio driver :  


### PR DESCRIPTION
I wrote a tutorial about how to use Minio as Laravel Cloud Storage driver.  
In new version of `aws-sdk` setting `bucket_endpoint` and `use_path_style_endpoint` is important to work with Minio.

I hope this tutorial is useful for other developers.
Also #155 is about to add Minio as Default Storage driver for laravel.