### PR TITLE
Typo in documentation to secure minio with let's encrypt

### DIFF
--- a/docs/generate-lets-encypt-certificate-using-certbot-for-minio.md
+++ b/docs/generate-lets-encypt-certificate-using-certbot-for-minio.md
@@ -39,7 +39,7 @@ lrwxrwxrwx 1 root root  40 Aug  2 09:58 privkey.pem -> ../../archive/myminio.com
 ### Step 4: Set up SSL on Minio Server with the certificates.
 The certificate and key generated via Certbot needs to be placed inside user's home directory.
 ```sh
-$ cp /etc/letsencrypt/live/myminio.com/fullychain.pem /home/user/.minio/certs/public.crt
+$ cp /etc/letsencrypt/live/myminio.com/fullchain.pem /home/user/.minio/certs/public.crt
 $ cp /etc/letsencrypt/live/myminio.com/privkey.pem /home/user/.minio/certs/private.key
 ```
 


### PR DESCRIPTION
I need to modify in [step 4](https://github.com/minio/cookbook/blob/master/docs/generate-lets-encypt-certificate-using-certbot-for-minio.md#step-4-set-up-ssl-on-minio-server-with-the-certificates)`fullychain.pem` (inexistent file) to `fullchain.pem` to enable https on my minio server.

We can see present's files in let's encrypt dir with [Step 3](https://github.com/minio/cookbook/blob/master/docs/generate-lets-encypt-certificate-using-certbot-for-minio.md#step-3-verify-certificates) 