### PR TITLE
Remove --preferred-challenges tls-sni

### DIFF
--- a/docs/generate-lets-encypt-certificate-using-certbot-for-minio.md
+++ b/docs/generate-lets-encypt-certificate-using-certbot-for-minio.md
@@ -21,7 +21,7 @@ Install Certbot by following the documentation at https://certbot.eff.org/
 
 ### Step 2: Generate Let's Encrypt cert
 ```sh
-# certbot certonly --standalone --preferred-challenges tls-sni -d myminio.com --staple-ocsp -m test@yourdomain.io --agree-tos
+# certbot certonly --standalone -d myminio.com --staple-ocsp -m test@yourdomain.io --agree-tos
 ```
 
 ### Step 3: Verify Certificates

--- a/docs/zh_CN/generate-lets-encypt-certificate-using-certbot-for-minio.md
+++ b/docs/zh_CN/generate-lets-encypt-certificate-using-certbot-for-minio.md
@@ -21,7 +21,7 @@
 
 ### 步骤2: 生成Let's Encrypt证书
 ```sh
-# certbot certonly --standalone --preferred-challenges tls-sni -d myminio.com --staple-ocsp -m test@yourdomain.io --agree-tos
+# certbot certonly --standalone -d myminio.com --staple-ocsp -m test@yourdomain.io --agree-tos
 ```
 
 ### 步骤3: 验证证书


### PR DESCRIPTION
Let’s Encrypt permanently disabled the TLS-SNI-01 challenge 1.2k
due to a security report, as of 2018-01-09.

Fixes https://github.com/minio/minio/issues/5922