### PR TITLE
Syntax improvement, Comment optional nginx module

### DIFF
--- a/docs/setup-nginx-proxy-with-minio.md
+++ b/docs/setup-nginx-proxy-with-minio.md
@@ -30,14 +30,15 @@ server {
  proxy_buffering off;
 
  location / {
-   proxy_http_version 1.1
+   proxy_http_version 1.1;
    proxy_set_header Host $http_host;
    # proxy_ssl_session_reuse on; # enable this if you are internally connecting over SSL
    proxy_read_timeout 15m; # Default value is 60s which is not sufficient for MinIO.
    proxy_send_timeout 15m; # Default value is 60s which is not sufficient for MinIO.
    proxy_request_buffering off; # Disable any internal request bufferring.
-   proxy_pass http://localhost:9000;
-   health_check uri=/minio/health/ready;
+   proxy_pass http://localhost:9000; # If you are using docker-compose this would be the hostname i.e. minio
+   # Health Check endpoint might go here. See https://www.nginx.com/resources/wiki/modules/healthcheck/
+   # /minio/health/ready;
  }
 }
 ```
@@ -51,7 +52,7 @@ Note:
 * Nginx disallows special characters by default.  Set ``ignore_invalid_headers off;`` to allow headers with special characters.
 
 ### Proxy requests based on the bucket
-If you want to serve web-application and MinIO from the same nginx port then you can proxy the MinIO requests based on the bucket name
+If you want to serve web-application and MinIO from the same nginx port then you can proxy the MinIO requests based on the bucket name using path based routing. For nginx this uses the `location` directive, which also supports object key pattern-match based proxy splitting.
 
 ```sh
  # Proxy requests to the bucket "photos" to MinIO server running on port 9000

--- a/docs/setup-nginx-proxy-with-minio.md
+++ b/docs/setup-nginx-proxy-with-minio.md
@@ -57,7 +57,7 @@ If you want to serve web-application and MinIO from the same nginx port then you
 ```sh
  # Proxy requests to the bucket "photos" to MinIO server running on port 9000
  location /photos/ {
-   proxy_http_version 1.1
+   proxy_http_version 1.1;
    proxy_buffering off;
    # proxy_ssl_session_reuse on; # enable this if you are internally connecting over SSL
    proxy_read_timeout 15m; # Default value is 60s which is not sufficient for MinIO.
@@ -68,7 +68,7 @@ If you want to serve web-application and MinIO from the same nginx port then you
  }
  # Proxy any other request to the application server running on port 9001
  location / {
-   proxy_http_version 1.1
+   proxy_http_version 1.1;
    proxy_buffering off;
    # proxy_ssl_session_reuse on; # enable this if you are internally connecting over SSL
    proxy_read_timeout 15m; # Default value is 60s which is too less for MinIO.


### PR DESCRIPTION
When I found this after having some difficulties proxying minio in a local environment; I found it did not work.

I've many years server-admin, so I knew where to look for errors and could spot points for change. I know people this wouldn't be true for, who would benefit from using minio in this setup.

- Comments out `healthcheck` and points at documentation from vendor
- adds missing semi-colon
- adds note about backend hostname in docker[-compose] environments
- small addendum about the location directive