### PR TITLE
Update rclone-with-minio.md

### DIFF
--- a/docs/rclone-with-minio.md
+++ b/docs/rclone-with-minio.md
@@ -58,6 +58,7 @@ Which makes the config file look like this
 
 ```sh
 [minio]
+type = s3
 env_auth = false
 access_key_id = USWUXHGYZQYFYFFIT3RE
 secret_access_key = MOJRH0mkL1IPauahWITSVvyDrQbEEIwljvmxdq03F


### PR DESCRIPTION
fixes #269 `type = s3` necessary for rclone to work. 