### PR TITLE
need traefik 1.7 not 2.0

### DIFF
--- a/docs/distributed-minio-with-traefik-as-loadbalancer-in-swarm.md
+++ b/docs/distributed-minio-with-traefik-as-loadbalancer-in-swarm.md
@@ -115,7 +115,7 @@ services:
       - access_key
 
   minioproxy:
-    image: traefik
+    image: traefik:v1.7.16
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:


### PR DESCRIPTION
In order to use the static config, we need to use traefik 1.7 not 2.0.  More details are in this issue https://github.com/containous/traefik/issues/5422 by ANOXI